### PR TITLE
Add type="email" to contact form email input for better mobile UX

### DIFF
--- a/src/app/home/_components/contact/form.tsx
+++ b/src/app/home/_components/contact/form.tsx
@@ -95,7 +95,7 @@ export default function Form() {
 
         <label className="grid">
           <div className="font-bold text-lg">Email</div>
-          <input name="email" className="border-2 p-2 rounded-md" />
+          <input name="email" type="email" className="border-2 p-2 rounded-md" />
           {validationErrors?.email && <Error>{validationErrors.email}</Error>}
         </label>
 
@@ -121,7 +121,7 @@ export default function Form() {
             <option hidden value=""></option>
             <option value="privatversichert">Privatversichert</option>
             <option value="beihilfe">Beihilfe</option>
-            <option value="heilfürsorge">Heilfürsorge</option>
+            <option value="heilførsorge">Heilførsorge</option>
             <option value="selbstzahler">Selbstzahler</option>
           </select>
           {validationErrors?.payment && (

--- a/src/app/home/_components/contact/form.tsx
+++ b/src/app/home/_components/contact/form.tsx
@@ -121,7 +121,7 @@ export default function Form() {
             <option hidden value=""></option>
             <option value="privatversichert">Privatversichert</option>
             <option value="beihilfe">Beihilfe</option>
-            <option value="heilførsorge">Heilførsorge</option>
+            <option value="heilfürsorge">Heilfürsorge</option>
             <option value="selbstzahler">Selbstzahler</option>
           </select>
           {validationErrors?.payment && (


### PR DESCRIPTION
## What

Adds `type="email"` to the email address input field in the contact form.

## Why

Without `type="email"`, mobile users (iOS and Android) get a generic QWERTY keyboard when tapping the email field. With `type="email"`, the OS shows a keyboard optimized for email entry — with `@` and `.` prominently visible in the default layout, so users do not have to switch keyboard layers to type an email address.

Additionally, `type="email"` enables:
- Browser autocomplete for saved email addresses
- Built-in format validation in browsers that support it

This is a one-character change with zero risk and an immediate UX improvement for anyone filling out the form on a smartphone.