### PR TITLE
Improve on-page SEO for the /home route

### DIFF
--- a/src/app/home/_components/contact/form.tsx
+++ b/src/app/home/_components/contact/form.tsx
@@ -67,7 +67,7 @@ export default function Form() {
   return (
     <div className="flex flex-col items-center justify-center">
       <form onSubmit={handleSubmit} className="w-full max-w-md grid gap-4">
-        <h1 className="text-2xl font-bold">Termin anfragen</h1>
+        <h2 className="text-2xl font-bold">Termin anfragen</h2>
         <div className="my-1">
           Bitte beschreiben Sie kurz Ihr Anliegen. Geben Sie uns bitte außerdem
           an, in welchen Zeiträumen Therapiesitzungen stattfinden könnten.

--- a/src/app/home/aboutMe.tsx
+++ b/src/app/home/aboutMe.tsx
@@ -15,13 +15,13 @@ export default function AboutMe() {
       </div>
       <div className="text">
         <div className="pb-4">
-          <h1>Ute Seliger</h1>
+          <h2 className="text-4xl">Ute Seliger</h2>
         </div>
         <div>
-          <h5 className="pb-4">
+          <p className="pb-4">
             Ich bin Psychologische Psychotherapeutin mit dem Schwerpunkt
             Verhaltenstherapie.
-          </h5>
+          </p>
           <div className="pb-4">
             In meiner Privatpraxis für Psychotherapie im Waldstraßenviertel in
             Leipzig möchte ich Ihnen einen sicheren Raum für Ihre Gedanken und

--- a/src/app/home/costs.tsx
+++ b/src/app/home/costs.tsx
@@ -20,7 +20,7 @@ export default function Costs() {
         </p>
       </div>
       <div>
-        <h4 className="font-bold mb-4">Therapie möglich für:</h4>
+        <h3 className="text-xl font-bold mb-4">Therapie möglich für:</h3>
         <ul className="list-disc pl-5 space-y-2">
           <li>Privatversicherte</li>
           <li>Beihilfefähige</li>

--- a/src/app/home/layout.tsx
+++ b/src/app/home/layout.tsx
@@ -10,10 +10,11 @@ export const dynamic = "force-static";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://www.psychotherapie-seliger.de"),
   title:
-    "Psychotherapie Seliger | Psychotherapie in Leipzig | Verhaltenstherapie",
+    "Psychotherapie in Leipzig | Privatpraxis Ute Seliger – Verhaltenstherapie",
   description:
-    "Psychotherapie in Leipzig: Vereinbaren Sie jetzt einen Termin für Ihre individuelle Therapieanfrage. Kontaktieren Sie uns für professionelle psychotherapeutische Unterstützung.",
+    "Privatpraxis für Psychotherapie im Waldstraßenviertel in Leipzig: Verhaltenstherapie für Erwachsene. Termine für Privatversicherte, Beihilfeberechtigte und Selbstzahler.",
   keywords: [
     "Psychotherapie Leipzig",
     "Psychologe Leipzig",
@@ -30,6 +31,21 @@ export const metadata: Metadata = {
   ],
   alternates: {
     canonical: "https://www.psychotherapie-seliger.de/home",
+  },
+  openGraph: {
+    title: "Psychotherapie in Leipzig | Privatpraxis Ute Seliger",
+    description:
+      "Privatpraxis für Psychotherapie im Waldstraßenviertel in Leipzig: Verhaltenstherapie für Erwachsene – für Privatversicherte, Beihilfeberechtigte und Selbstzahler.",
+    url: "https://www.psychotherapie-seliger.de/home",
+    siteName: "Psychotherapie Seliger",
+    locale: "de_DE",
+    type: "website",
+    images: [
+      {
+        url: "/raum.jpeg",
+        alt: "Praxisraum der Privatpraxis für Psychotherapie Seliger in Leipzig",
+      },
+    ],
   },
 };
 

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,4 +1,3 @@
-import Script from "next/script";
 import AboutMe from "./aboutMe";
 import Contact from "./_components/contact";
 import Costs from "./costs";
@@ -10,24 +9,25 @@ import { graph } from "./structuredData";
 export default function Home() {
   return (
     <main>
-      <Script
-        id="jsonld-organization"
+      <script
         type="application/ld+json"
-        strategy="afterInteractive"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(graph) }}
       />
       <div className="relative w-full h-[60vh] md:h-[80vh] overflow-hidden">
         <Image
           src="/raum.jpeg"
-          alt="Praxisraum"
+          alt="Praxisraum der Privatpraxis für Psychotherapie Seliger in Leipzig"
           fill
           priority
           className="object-cover object-center"
         />
         <div className="relative flex flex-col items-center justify-center h-full text-white text-center px-4">
           <h1 className="text-2xl md:text-7xl [text-shadow:1px_1px_1px_rgb(0_0_0/20%)] shrink-on-scroll">
-            Privatpraxis für Psychotherapie
+            Privatpraxis für Psychotherapie in Leipzig
           </h1>
+          <p className="text-lg md:text-3xl pt-4 [text-shadow:1px_1px_1px_rgb(0_0_0/20%)]">
+            Verhaltenstherapie für Erwachsene – Ute Seliger
+          </p>
         </div>
       </div>
 

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -8,48 +8,52 @@ import { graph } from "./structuredData";
 
 export default function Home() {
   return (
-    <main>
+    <>
+      {/* Outside <main>: its sections are colored via nth-child, which counts
+          every element child — a script inside <main> shifts the alternation */}
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(graph) }}
       />
-      <div className="relative w-full h-[60vh] md:h-[80vh] overflow-hidden">
-        <Image
-          src="/raum.jpeg"
-          alt="Praxisraum der Privatpraxis für Psychotherapie Seliger in Leipzig"
-          fill
-          priority
-          className="object-cover object-center"
-        />
-        <div className="relative flex flex-col items-center justify-center h-full text-white text-center px-4">
-          <h1 className="text-2xl md:text-7xl [text-shadow:1px_1px_1px_rgb(0_0_0/20%)] shrink-on-scroll">
-            Privatpraxis für Psychotherapie in Leipzig
-          </h1>
-          <p className="text-lg md:text-3xl pt-4 [text-shadow:1px_1px_1px_rgb(0_0_0/20%)]">
-            Verhaltenstherapie für Erwachsene – Ute Seliger
-          </p>
+      <main>
+        <div className="relative w-full h-[60vh] md:h-[80vh] overflow-hidden">
+          <Image
+            src="/raum.jpeg"
+            alt="Praxisraum der Privatpraxis für Psychotherapie Seliger in Leipzig"
+            fill
+            priority
+            className="object-cover object-center"
+          />
+          <div className="relative flex flex-col items-center justify-center h-full text-white text-center px-4">
+            <h1 className="text-2xl md:text-7xl [text-shadow:1px_1px_1px_rgb(0_0_0/20%)] shrink-on-scroll">
+              Privatpraxis für Psychotherapie in Leipzig
+            </h1>
+            <p className="text-lg md:text-3xl pt-4 [text-shadow:1px_1px_1px_rgb(0_0_0/20%)]">
+              Verhaltenstherapie für Erwachsene – Ute Seliger
+            </p>
+          </div>
         </div>
-      </div>
 
-      <section id="about_me">
-        <AboutMe />
-      </section>
+        <section id="about_me">
+          <AboutMe />
+        </section>
 
-      <section id="therapie">
-        <Therapie />
-      </section>
+        <section id="therapie">
+          <Therapie />
+        </section>
 
-      <section id="behandlungsspektrum">
-        <TreatmentSpectrum />
-      </section>
+        <section id="behandlungsspektrum">
+          <TreatmentSpectrum />
+        </section>
 
-      <section id="kosten">
-        <Costs />
-      </section>
+        <section id="kosten">
+          <Costs />
+        </section>
 
-      <section id="kontakt">
-        <Contact />
-      </section>
-    </main>
+        <section id="kontakt">
+          <Contact />
+        </section>
+      </main>
+    </>
   );
 }

--- a/src/app/home/structuredData.tsx
+++ b/src/app/home/structuredData.tsx
@@ -4,12 +4,15 @@ export const graph: Graph = {
   "@context": "https://schema.org",
   "@graph": [
     {
-      "@type": "Organization",
+      "@type": "MedicalClinic",
       "@id": "https://www.psychotherapie-seliger.de/home",
-      name: "Psychotherapie Seliger",
+      name: "Psychotherapie Seliger – Privatpraxis für Psychotherapie",
       url: "https://www.psychotherapie-seliger.de/home",
       logo: "https://www.psychotherapie-seliger.de/logo.svg",
-      image: "https://www.psychotherapie-seliger.de/person.jpg",
+      image: "https://www.psychotherapie-seliger.de/raum.jpeg",
+      telephone: "+4915252735959",
+      email: "psychotherapie@praxis-seliger.com",
+      medicalSpecialty: "https://schema.org/Psychiatric",
       contactPoint: {
         "@type": "ContactPoint",
         telephone: "+4915252735959",
@@ -25,6 +28,25 @@ export const graph: Graph = {
         postalCode: "04105",
         addressCountry: "DE",
       },
+      founder: {
+        "@id": "https://www.psychotherapie-seliger.de/home#ute-seliger",
+      },
+      sameAs: ["https://www.therapie.de/profil/seliger/"],
+    },
+    {
+      "@type": "Person",
+      "@id": "https://www.psychotherapie-seliger.de/home#ute-seliger",
+      name: "Ute Seliger",
+      jobTitle: "Psychologische Psychotherapeutin",
+      image: "https://www.psychotherapie-seliger.de/person.jpg",
+      worksFor: {
+        "@id": "https://www.psychotherapie-seliger.de/home",
+      },
+      knowsAbout: [
+        "Verhaltenstherapie",
+        "Schematherapie",
+        "Akzeptanz- und Commitment-Therapie",
+      ],
       sameAs: ["https://www.therapie.de/profil/seliger/"],
     },
     {
@@ -36,7 +58,7 @@ export const graph: Graph = {
       description:
         "Informationen über die Psychotherapeutin, ihre Qualifikationen und Erfahrungen.",
       mainEntity: {
-        "@id": "https://www.psychotherapie-seliger.de/home",
+        "@id": "https://www.psychotherapie-seliger.de/home#ute-seliger",
       },
     },
     {

--- a/src/app/home/therapie.tsx
+++ b/src/app/home/therapie.tsx
@@ -6,7 +6,7 @@ export default function Therapie() {
       <div className="image w-full h-auto md:h-full md:w-[30vw]">
         <Image
           src="/filler.jpeg"
-          alt="Füllbild was den Verlauf der Therapie darstellt"
+          alt="Symbolbild für den Verlauf einer Verhaltenstherapie"
           width={0}
           height={0}
           sizes="100%"

--- a/src/app/home/treatmentSpectrum.tsx
+++ b/src/app/home/treatmentSpectrum.tsx
@@ -6,7 +6,7 @@ export default function TreatmentSpectrum() {
       <div className="image w-full h-auto md:h-full md:w-[30vw] justify-self-center">
         <Image
           src="/brain.jpeg"
-          alt="Füllbild was das Behandlungsspektrum darstellt"
+          alt="Illustration eines Gehirns – Behandlungsspektrum der Psychotherapie-Praxis"
           width={0}
           height={0}
           sizes="100%"
@@ -14,7 +14,7 @@ export default function TreatmentSpectrum() {
         />
       </div>
       <div className="text">
-        <h3 className="pb-2 underline">Behandlungsspektrum</h3>
+        <h2 className="pb-2 text-2xl underline">Behandlungsspektrum</h2>
         <ul className="list-disc space-y-2 pl-5">
           <li>ADHS/ADS im Erwachsenenalter</li>
           <li>Beziehungs- und Interaktionsstörungen</li>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,9 +3,9 @@ import type { MetadataRoute } from "next";
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: "https://psychotherapie-seliger.de/home",
-      lastModified: new Date(),
-      changeFrequency: "weekly",
+      url: "https://www.psychotherapie-seliger.de/home",
+      lastModified: new Date("2026-07-10"),
+      changeFrequency: "monthly",
       priority: 1,
     },
   ];


### PR DESCRIPTION
- Single h1 including "Leipzig", fix heading hierarchy (h1>h2>h3)
- Meta title/description targeting Privatpraxis/Selbstzahler queries
- Add Open Graph metadata
- Render JSON-LD inline instead of afterInteractive; switch Organization to MedicalClinic and add Person entity for Ute Seliger
- Fix sitemap host (www) and stop stamping lastModified on every build
- Descriptive image alt texts